### PR TITLE
Fixes typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ function doSomething(scroll_pos) {
   // do something with the scroll position
 }
 
-const scheduled = rafSchedule(doSomething);
+const schedule = rafSchedule(doSomething);
 
 window.addEventListener('scroll', function() {
   schedule(window.scrollY);


### PR DESCRIPTION
While reading through the README, I noticed a small typo in some example code. Thanks for making a neat utility like this. :+1: