### PR TITLE
Add changelog pointing to Github Releases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+This project adheres to [Semantic Versioning 2.0](http://semver.org/).
+All release notes and upgrade notes can be found on our [Github Releases](https://github.com/alexreardon/raf-schd/releases) page.


### PR DESCRIPTION
It took me a while to find the upgrade notes. It might be a good idea to add a changelog file pointing to the releases.